### PR TITLE
Ensure .ssh directory is created

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,20 @@
 define sshuserconfig(
+  $unix_user = $title,
   $ssh_config_dir = undef
 ) {
 
-  $unix_user = $title
   if $ssh_config_dir == undef {
     $ssh_config_dir_prefix = "/home/${unix_user}/.ssh"
   } else {
     $ssh_config_dir_prefix = $ssh_config_dir
   }
   $ssh_config_file = "${ssh_config_dir_prefix}/config"
+
+  file { $ssh_config_dir :
+    ensure => 'directory',
+    owner => $unix_user,
+    mode => 755
+  }
 
   concat { $ssh_config_file :
     owner => $unix_user


### PR DESCRIPTION
To be self contained and composable the module should create the `.ssh` on its own. Relying on the directory already being present can lead to errors.
