### PR TITLE
only use the configured "IdentityFile"

### DIFF
--- a/spec/defines/remotehost_spec.rb
+++ b/spec/defines/remotehost_spec.rb
@@ -35,6 +35,10 @@ describe 'sshuserconfig::remotehost' do
     }
   }
 
+  it 'should only use the given IdentityFile' do
+    should contain_concat__fragment("ssh_userconfig_#{some_unix_user}_#{some_hostalias}")\
+      .with_content(%r{^\s+IdentitiesOnly yes$})
+  end
 
   it 'should have a configurable port' do
     params[:remote_port] = 2022
@@ -123,7 +127,8 @@ EOF
   HostName #{test_data[:remote_host]}
   Port #{default_port}
   User #{some_git_remote_user}
-  IdentityFile #{synthesized_privkey_path}\n\n}u)\
+  IdentityFile #{synthesized_privkey_path}
+  IdentitiesOnly yes\n\n}u)\
               .with_target(ssh_config_file)
           end
 

--- a/templates/fragment.erb
+++ b/templates/fragment.erb
@@ -3,6 +3,7 @@ Host <%= @title %>
   Port <%= @remote_port %>
   User <%= @remote_username %>
   IdentityFile <%= @synthesized_privkey_path %>
+  IdentitiesOnly yes
 <% if @connect_timeout -%>
   ConnectTimeout <%=  @connect_timeout %>
 <% end %>


### PR DESCRIPTION
from `ssh_config`:

-- IdentitiesOnly
Specifies  that ssh(1) should only use the authentication identity files
configured in the ssh_config files, even if ssh-agent(1) or a
PKCS11Provider offers  more identities. The argument  to  this  keyword
must be `yes` or `no`. This option is intended for situations where
ssh-agent offers many different identities. The default is `no`.

This can lead to incorrect behaviour when i.e talking to github.com
when another identity exists in the environment (i.e. ssh-agent). As
_all_ keys that reside on github.com are able to ssh there, the first
one will win, but won't necessarily have proper access to the
repository.

set `IdentitiesOnly` to `yes` by default.

@s0enke PHAL
